### PR TITLE
Use localplayer to avoid crash

### DIFF
--- a/description.txt
+++ b/description.txt
@@ -1,1 +1,0 @@
-This mod adds tool ware level alerts. When a tool gets below a level (set by .warn_lvl), it will display a colored warning message with sound.

--- a/init.lua
+++ b/init.lua
@@ -74,7 +74,7 @@ minetest.register_on_punchnode(function(pos, node)
 end)
 
 function checkTool()
-    local tool = minetest.get_wielded_item()
+    local tool = minetest.localplayer:get_wielded_item()
     local warn = modstorage:get_string("warn")
 
     if last_tool ~= tool:get_name() then

--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,3 @@
+name = toolbuddy
+description = This mod adds tool aware level alerts. When a tool gets below a level (set by .warn_lvl), it will display a colored warning message with sound.
+author = ChimneySwift


### PR DESCRIPTION
Under 5.5.0-dev, my client crashes back to the main menu with this stack trace:

```
Access denied. Reason: Lua: Runtime error from mod '' in callback on_item_use(): toolbuddy:init.lua:77: attempt to call field 'get_wielded_item' (a nil value)
stack traceback:
	toolbuddy:init.lua:77: in function 'checkTool'
	toolbuddy:init.lua:69: in function '?'
	*builtin*:client/register.lua:26: in function <*builtin*:client/register.lua:14>
```

Since [minetest/1292bdbbcec45613c95aff9f2ea88aa49af25011](https://github.com/minetest/minetest/commit/1292bdbbcec45613c95aff9f2ea88aa49af25011), you need to use minetest.localplayer to call get_wielded_item as it was changed from a method on the minetest object to a method on the LocalPlayer userdata. This PR will update the CSM for 5.3 but would break backwards compatibility.